### PR TITLE
Tect 306: bump lib version to 5.19.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ Thumbs.db
 
 # Cov report
 .coverage
+
+# Mise
+mise.toml

--- a/poetry.lock
+++ b/poetry.lock
@@ -1708,26 +1708,23 @@ wcwidth = "*"
 
 [[package]]
 name = "protobuf"
-version = "4.21.6"
+version = "4.25.8"
 description = ""
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "protobuf-4.21.6-cp310-abi3-win32.whl", hash = "sha256:49f88d56a9180dbb7f6199c920f5bb5c1dd0172f672983bb281298d57c2ac8eb"},
-    {file = "protobuf-4.21.6-cp310-abi3-win_amd64.whl", hash = "sha256:7a6cc8842257265bdfd6b74d088b829e44bcac3cca234c5fdd6052730017b9ea"},
-    {file = "protobuf-4.21.6-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:ba596b9ffb85c909fcfe1b1a23136224ed678af3faf9912d3fa483d5f9813c4e"},
-    {file = "protobuf-4.21.6-cp37-abi3-manylinux2014_aarch64.whl", hash = "sha256:4143513c766db85b9d7c18dbf8339673c8a290131b2a0fe73855ab20770f72b0"},
-    {file = "protobuf-4.21.6-cp37-abi3-manylinux2014_x86_64.whl", hash = "sha256:b6cea204865595a92a7b240e4b65bcaaca3ad5d2ce25d9db3756eba06041138e"},
-    {file = "protobuf-4.21.6-cp37-cp37m-win32.whl", hash = "sha256:9666da97129138585b26afcb63ad4887f602e169cafe754a8258541c553b8b5d"},
-    {file = "protobuf-4.21.6-cp37-cp37m-win_amd64.whl", hash = "sha256:308173d3e5a3528787bb8c93abea81d5a950bdce62840d9760effc84127fb39c"},
-    {file = "protobuf-4.21.6-cp38-cp38-win32.whl", hash = "sha256:aa29113ec901281f29d9d27b01193407a98aa9658b8a777b0325e6d97149f5ce"},
-    {file = "protobuf-4.21.6-cp38-cp38-win_amd64.whl", hash = "sha256:8f9e60f7d44592c66e7b332b6a7b4b6e8d8b889393c79dbc3a91f815118f8eac"},
-    {file = "protobuf-4.21.6-cp39-cp39-win32.whl", hash = "sha256:80e6540381080715fddac12690ee42d087d0d17395f8d0078dfd6f1181e7be4c"},
-    {file = "protobuf-4.21.6-cp39-cp39-win_amd64.whl", hash = "sha256:77b355c8604fe285536155286b28b0c4cbc57cf81b08d8357bf34829ea982860"},
-    {file = "protobuf-4.21.6-py2.py3-none-any.whl", hash = "sha256:07a0bb9cc6114f16a39c866dc28b6e3d96fa4ffb9cc1033057412547e6e75cb9"},
-    {file = "protobuf-4.21.6-py3-none-any.whl", hash = "sha256:c7c864148a237f058c739ae7a05a2b403c0dfa4ce7d1f3e5213f352ad52d57c6"},
-    {file = "protobuf-4.21.6.tar.gz", hash = "sha256:6b1040a5661cd5f6e610cbca9cfaa2a17d60e2bb545309bc1b278bb05be44bdd"},
+    {file = "protobuf-4.25.8-cp310-abi3-win32.whl", hash = "sha256:504435d831565f7cfac9f0714440028907f1975e4bed228e58e72ecfff58a1e0"},
+    {file = "protobuf-4.25.8-cp310-abi3-win_amd64.whl", hash = "sha256:bd551eb1fe1d7e92c1af1d75bdfa572eff1ab0e5bf1736716814cdccdb2360f9"},
+    {file = "protobuf-4.25.8-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:ca809b42f4444f144f2115c4c1a747b9a404d590f18f37e9402422033e464e0f"},
+    {file = "protobuf-4.25.8-cp37-abi3-manylinux2014_aarch64.whl", hash = "sha256:9ad7ef62d92baf5a8654fbb88dac7fa5594cfa70fd3440488a5ca3bfc6d795a7"},
+    {file = "protobuf-4.25.8-cp37-abi3-manylinux2014_x86_64.whl", hash = "sha256:83e6e54e93d2b696a92cad6e6efc924f3850f82b52e1563778dfab8b355101b0"},
+    {file = "protobuf-4.25.8-cp38-cp38-win32.whl", hash = "sha256:27d498ffd1f21fb81d987a041c32d07857d1d107909f5134ba3350e1ce80a4af"},
+    {file = "protobuf-4.25.8-cp38-cp38-win_amd64.whl", hash = "sha256:d552c53d0415449c8d17ced5c341caba0d89dbf433698e1436c8fa0aae7808a3"},
+    {file = "protobuf-4.25.8-cp39-cp39-win32.whl", hash = "sha256:077ff8badf2acf8bc474406706ad890466274191a48d0abd3bd6987107c9cde5"},
+    {file = "protobuf-4.25.8-cp39-cp39-win_amd64.whl", hash = "sha256:f4510b93a3bec6eba8fd8f1093e9d7fb0d4a24d1a81377c10c0e5bbfe9e4ed24"},
+    {file = "protobuf-4.25.8-py3-none-any.whl", hash = "sha256:15a0af558aa3b13efef102ae6e4f3efac06f1eea11afb3a57db2901447d9fb59"},
+    {file = "protobuf-4.25.8.tar.gz", hash = "sha256:6135cf8affe1fc6f76cced2641e4ea8d3e59518d1f24ae41ba97bcad82d397cd"},
 ]
 
 [[package]]
@@ -2688,14 +2685,14 @@ files = [
 
 [[package]]
 name = "splight-lib"
-version = "5.18.3"
+version = "5.19.8"
 description = "Splight Library"
 optional = false
 python-versions = "<4.0.0,>=3.11"
 groups = ["main"]
 files = [
-    {file = "splight_lib-5.18.3-py3-none-any.whl", hash = "sha256:5900920d231dda4ca09d57f7119c9cb00a454a1ed86ee90cfc821865bd7c4b11"},
-    {file = "splight_lib-5.18.3.tar.gz", hash = "sha256:9c479bb973874471336d0d2a2a150cff568daaa295d667302fbaf9ff77fb1163"},
+    {file = "splight_lib-5.19.8-py3-none-any.whl", hash = "sha256:e6673635b3879eeec84098afcae193321e3367b24acedd27d07a5fc953b04229"},
+    {file = "splight_lib-5.19.8.tar.gz", hash = "sha256:4da2ee94adeee86e04f805cb490590d16ba6a8076daacac7deea69272675bba2"},
 ]
 
 [package.dependencies]
@@ -2714,7 +2711,7 @@ pandas = "2.2.3"
 parameterized = "0.8.1"
 pathspec = "0.11.1"
 progressbar2 = "4.4.1"
-protobuf = "4.21.6"
+protobuf = "4.25.8"
 py7zr = "0.20.8"
 pydantic = "2.4.2"
 pydantic-settings = "2.0.3"
@@ -2918,4 +2915,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4.0.0"
-content-hash = "e46c35523427339864e1d0971f2c3ea1ad1ce3559e2568cdda6e5ef207c199ce"
+content-hash = "a8ad0e277066cf8c404b61a1a2b264471f5f03ae141424b9535029d2337903d5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "splight-cli"
-version = "5.5.2"
+version = "5.5.3"
 description = "Splight Command Line Interface"
 authors = [
     {name = "Splight Dev",email = "dev@splight-ae.com"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "click (==8.0.4)",
     "click-default-group (==1.2.2)",
     "setuptools (==80.7.1)",
-    "splight-lib (>=5.18.3,<6.0.0)",
+    "splight-lib (>=5.19.8,<6.0.0)",
     "py7zr (==0.20.8)",
     "typer (==0.15.1)",
     "colorama (==0.4.4)",


### PR DESCRIPTION
We need to bump this version to fix a protobuf vulnerability